### PR TITLE
Added Shopware 6.7 in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "license": "MIT",
     "description": "A meta package providing recipes for Shopware K8S Operator",
     "require": {
-        "shopware/core": "~6.6.0",
+        "shopware/core": "~6.6.0 || ~6.7.0",
         "open-telemetry/exporter-otlp": "^1.1",
         "open-telemetry/transport-grpc": "^1.1",
         "shopware/opentelemetry": "^0.1.5",


### PR DESCRIPTION
This pull request updates the `composer.json` file to expand compatibility with newer versions of `shopware/core`.

Dependency updates:

* [`composer.json`](diffhunk://#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34L7-R7): Modified the version constraint for `shopware/core` to include compatibility with `~6.7.0` in addition to `~6.6.0`.